### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/weback/manifest.json
+++ b/custom_components/weback/manifest.json
@@ -7,5 +7,6 @@
   ],
   "codeowners": [
     "@opravdin"
-  ]
+  ],
+  "version": "1.0.3"
 }


### PR DESCRIPTION
To solve the `ERROR (SyncWorker_4) [homeassistant.loader] The custom integration 'weback' does not have a valid version key (None) in the manifest file and was blocked from loading. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions for more details` error.